### PR TITLE
refactor: change notification trigger from time-based to DB state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # SEEK NEW
 
-You-Know-Where Data Engineer Job Tracker
+New listing tracker on you-know-where (popular job site in AU and NZ). I use it to track Data Engineer jobs.
 
 simply run `./run.sh` or
 - Get new listings for the 24 hours (customizable)
-- Send Telegram notifications for job listings started within the last 10 minutes (customizable)
+- Send Telegram notifications for new job listings (not yet in database)
 
 Feel free to `crontab -e` to schedule periodic runs, e.g., every 10 minutes:
 ```
 */10 * * * * /path/to/your/project/run.sh
 ```
 
-In future, I may add visualizations and dashboards using tools like streamlit to analyze job market trends.
+## Future Enhancements
+
+- Visualizations and dashboards using tools like streamlit to analyze job market trends

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -9,7 +9,6 @@ from .database import (
     get_connection,
     init_database,
     upsert_jobs,
-    get_active_jobs,
     get_statistics,
 )
 
@@ -18,6 +17,5 @@ __all__ = [
     "get_connection",
     "init_database",
     "upsert_jobs",
-    "get_active_jobs",
     "get_statistics",
 ]

--- a/src/database.py
+++ b/src/database.py
@@ -9,7 +9,12 @@ from datetime import datetime
 import duckdb
 from dotenv import load_dotenv
 
+from src.utils.my_logger import get_logger
+from src.utils.tg import send_telegram
+
 load_dotenv()
+
+LOGGER = get_logger('default')
 
 
 def get_connection():
@@ -133,12 +138,17 @@ def _extract_work_arrangements_text(work_arrangements) -> str:
 def upsert_jobs(conn, jobs: list[dict]) -> dict:
     """
     Insert or update jobs in the database
+    Sends Telegram notification for new jobs only
     
     Returns:
         dict with statistics (new_jobs, updated_jobs, total_active)
     """
     if not jobs:
         return {"new_jobs": 0, "updated_jobs": 0, "total_active": 0}
+    
+    # Get Telegram credentials
+    tg_api_key = os.getenv("TG_API_KEY")
+    tg_chat_id = os.getenv("TG_CHAT_ID")
     
     new_jobs = 0
     updated_jobs = 0
@@ -193,7 +203,7 @@ def upsert_jobs(conn, jobs: list[dict]) -> dict:
             ])
             updated_jobs += 1
         else:
-            # New job - insert it
+            # New job - insert it and send notification
             conn.execute("""
                 INSERT INTO pg.jobs (
                     id, title, teaser, employer_id, employer_name, role_id,
@@ -216,6 +226,21 @@ def upsert_jobs(conn, jobs: list[dict]) -> dict:
                 job.get('salaryLabel')
             ])
             new_jobs += 1
+            
+            # Send Telegram notification for new job
+            if tg_api_key and tg_chat_id:
+                try:
+                    msg = (
+                        f"Title: {job.get('title', 'N/A')}\n"
+                        f"Company: {job.get('employer_name', 'N/A')}\n"
+                        f"Location: {locations_text or 'N/A'}\n"
+                        f"Salary: {job.get('salaryLabel', 'Not specified')}\n"
+                        f"Link: https://www.seek.com.au/job/{job_id}"
+                    )
+                    send_telegram(tg_api_key, msg, tg_chat_id)
+                    LOGGER.info(f"📱 Telegram notification sent for job ID {job_id}")
+                except Exception as e:
+                    LOGGER.error(f"Failed to send Telegram notification for job {job_id}: {e}")
     
     # Get total jobs
     total_active = conn.execute("SELECT COUNT(*) FROM pg.jobs").fetchone()[0]
@@ -225,32 +250,6 @@ def upsert_jobs(conn, jobs: list[dict]) -> dict:
         "updated_jobs": updated_jobs,
         "total_active": total_active
     }
-
-
-def get_active_jobs(conn) -> list[dict]:
-    """Get all jobs"""
-    result = conn.execute("""
-        SELECT 
-            id, title, employer_name, salary_label, 
-            locations, country_codes, work_types, work_arrangements
-        FROM pg.jobs 
-        ORDER BY listing_date DESC
-    """).fetchall()
-    
-    jobs = []
-    for row in result:
-        jobs.append({
-            'id': row[0],
-            'title': row[1],
-            'employer_name': row[2],
-            'salary_label': row[3],
-            'locations': row[4] if row[4] else "",
-            'country_codes': row[5] if row[5] else "",
-            'work_types': row[6] if row[6] else "",
-            'work_arrangements': row[7] if row[7] else ""
-        })
-    
-    return jobs
 
 
 def get_statistics(conn) -> dict:

--- a/src/search.py
+++ b/src/search.py
@@ -2,36 +2,13 @@
 import os
 import subprocess
 import re
-from datetime import datetime, timedelta
 
 from src.utils.my_logger import get_logger
-from src.utils.tg import send_telegram
 
 from dotenv import load_dotenv
 load_dotenv()
 
 LOGGER = get_logger('default')
-tg_api_key = os.getenv("TG_API_KEY")
-tg_chat_id = os.getenv("TG_CHAT_ID")
-
-
-def is_less_than_10m(listing_date: str) -> bool:
-    """
-    Check if a job listing date is less than 10 minutes old
-
-    Args:
-        listing_date: ISO 8601 formatted date string (e.g., "2025-11-03T06:40:11Z")
-        
-    Returns:
-        True if listing is less than 10 minutes old, False otherwise
-    """
-    try:
-        listing_datetime = datetime.fromisoformat(listing_date.replace('Z', '+00:00'))
-        time_diff = datetime.utcnow() - listing_datetime
-        return time_diff <= timedelta(minutes=10)
-    except Exception as e:
-        LOGGER.error(f"Error parsing listing date '{listing_date}': {e}")
-        return False
 
 
 def extract_job_data_from_url(url: str = None) -> list[dict]:
@@ -132,20 +109,7 @@ def extract_job_data_from_url(url: str = None) -> list[dict]:
                 if match:
                     LOGGER.info(f"✅ Match found for job ID {job_id} with role ID {job.get('roleId', '')}")
                     extracted_jobs.append(extracted_job)
-
-                    # Check if listing is less than 10 minutes old
-                    listing_date = job.get('listingDate', '')
-                    if all(
-                        listing_date,
-                        is_less_than_10m(listing_date)
-                    ):
-                        LOGGER.info(f"🆕 Recent listing found for job ID {job_id} listed at {listing_date}")
-                        msg = f"🆕 New job listing found: {job.get('title', 'N/A')} at {job.get('employer', {}).get('name', 'N/A')}\nLink: https://www.seek.com.au/job/{job_id}"
-                        send_telegram(
-                            tg_api_key,
-                            msg,
-                            tg_chat_id
-                        )
+            
             LOGGER.info(f"✅ Found {len(extracted_jobs)} unique jobs")
             return extracted_jobs
             


### PR DESCRIPTION
Send Telegram alerts only when inserting new jobs into the database, rather than checking if listing is less than 10 minutes old. More reliable and prevents duplicate notifications.